### PR TITLE
Small issue with pillar.example and logbasedir support

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -3,3 +3,5 @@ rsyslog:
   listentcp: true               # omit to disable listening on tcp port
   listenudp: true               # omit to disable listening on udp port
   imkllog: true             # omit to log kernel messages
+  logbasepath: /mnt/logs        # base path for logs to be saved to
+

--- a/rsyslog/files/rsyslog.conf.jinja
+++ b/rsyslog/files/rsyslog.conf.jinja
@@ -123,3 +123,8 @@ daemon.*;mail.*;\
 {% if config.target|default(false) %}
 *.* @{{ config.target }}
 {% endif %}
+
+{% if config.logbasepath|default(false) %}
+$template DailyPerHostLogs,"{{ config.logbasepath }}/%HOSTNAME%-%FROMHOST-IP%/%$YEAR%/%$MONTH%/%$DAY%.log"
+*.* -?DailyPerHostLogs
+{% endif %}


### PR DESCRIPTION
I found an issue with the previous pillar example and fixed that.

I also added a feature to support outputting logs to a basedir. We use it here with the remote listeners to put all incoming logs onto a separate volume sorted based on hostname and date.

Let me know if you have any questions or comments.
